### PR TITLE
Add flag to enable Content-MD5 header for PUTs

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"crypto/md5"
+	"encoding/base64"
 	"fmt"
 	"math"
 	"os"
@@ -102,7 +104,17 @@ func s3putGen() (up uploader, err error) {
 			src.attempts = maxTries
 			return
 		}
-
+		if opts.md5verify {
+			digest := md5.New()
+			_, err := digest.Write(body)
+			if err != nil {
+				panic(err)
+			}
+			md5sum := base64.StdEncoding.EncodeToString(digest.Sum(nil))
+			hdrs := headersDef{}
+			hdrs[ContentMD5] = md5sum
+			src.hdrs.merge(hdrs)
+		}
 		return bucket.PutHeader(src.fname, body, src.hdrs, s3.PublicRead)
 	}, nil
 }

--- a/setup.go
+++ b/setup.go
@@ -21,6 +21,7 @@ type options struct {
 	doCache, doUpload,
 	gzipHTML, encrypt bool
 	region string
+	md5verify bool
 }
 
 var opts *options
@@ -57,6 +58,7 @@ func processCmdLineFlags(opts *options) {
 	flag.BoolVar(&opts.doCache, "cache", true, "Do update the cache")
 	flag.BoolVar(&opts.gzipHTML, "gzip", true, "Gzip HTML files")
 	flag.BoolVar(&opts.encrypt, "encrypt", false, "Encrypt files on server side")
+	flag.BoolVar(&opts.md5verify, "md5verify", false, "Verify PUT's using s3 Content-MD5 header")
 	flag.Parse()
 }
 

--- a/source_file.go
+++ b/source_file.go
@@ -15,6 +15,7 @@ const (
 	ContentEncoding      = "Content-Encoding"
 	CacheControl         = "Cache-Control"
 	ContentType          = "Content-Type"
+	ContentMD5           = "Content-MD5"
 	ServerSideEncryption = "x-amz-server-side-encryption"
 )
 


### PR DESCRIPTION
I started by using the values from the file-hash map, when gzipping is used the data changes and the md5 sum becomes invalid so I  decided to always do it just before uploading instead.

The previous solution where I added an "md5" field to the sourceFile struct was easy to write tests for but could not without even more changes take into account gzipping which happens further down the line.
