### PR TITLE
A long overdue refactoring around S3:

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 language: go
 go:
-  - 1.3.3
+  - 1.6
 script: make test
 install:
-  - go get code.google.com/p/go.tools/cmd/cover
   - go get github.com/alexaandru/utils
-  - go get github.com/mitchellh/goamz/aws
-  - go get github.com/mitchellh/goamz/s3
+  - go get github.com/aws/aws-sdk-go
 

--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,13 @@ build:
 	@go build
 
 test:
-	@go test ./...
+	@AWS_SECRET_ACCESS_KEY=secret AWS_ACCESS_KEY_ID=secret go test ./...
 
 run: build
 	@./go3up -bucket="s3.ungur.ro" -source=test/output -cachefile=test/.go3up.txt
 
 cover:
-	@go test -coverprofile=coverage.out
+	@AWS_SECRET_ACCESS_KEY=secret AWS_ACCESS_KEY_ID=secret go test -coverprofile=coverage.out
 	@go tool cover -html=coverage.out
 
 clean:

--- a/README.md
+++ b/README.md
@@ -1,17 +1,31 @@
-go3up
-=====
+# Go S3 Uploader
 
 [![Build Status](https://travis-ci.org/alexaandru/go3up.png?branch=master)](https://travis-ci.org/alexaandru/go3up)
 [![GoDoc](https://godoc.org/github.com/alexaandru/go3up?status.png)](https://godoc.org/github.com/alexaandru/go3up)
-[![status](https://sourcegraph.com/api/repos/github.com/alexaandru/go3up/badges/status.png)](https://sourcegraph.com/github.com/alexaandru/go3up)
 
-Go S3 Uploader
+Go3Up (Go S3 Uploader) is a small S3 uploader tool.
 
-TODO
-----
+It was created in order to speed up S3 uploads by employing a local caching of files' md5 sums.
+That way, on subsequent runs, go3up can compute a list of the files that changed since the
+last upload and only upload those.
 
- - implement optimizations as per https://aws.amazon.com/articles/1904/ , the "Optimizing Network Performance" section in particular;
- - implement (optional) MD5 verification (see Content-MD5 at http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPUT.html);
- - implement multipart uploads + non "slurp mode" file read (+ make the limit where multipart kicks in configurable);
- - implement deletion of remote files missing on local;
- - (maybe) implement config file (from curr dir/home);
+The initial use case was a large static site (with 10k+ files) that frequently changed only
+a small subset of files (about ~100 routinely). In that particular case, the time reduction by
+switching from s3cmd to go3up was significant.
+
+On uploads with empty cache there may not be any benefit.
+
+The current focus of the tool is just one way/uploads (without deleting things that were removed
+locally, yet).
+
+## Usage
+
+Run `go3up -h` to get the help. You can save your preferences to a .go3up.json config file by
+passing your command line flags as usual and adding "-save" at the end.
+
+For authentication, see http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html
+as we pretty much support all of those options, in this order: shared profile; EC2 role; env vars.
+
+## TODO
+
+ - implement (optional) deletion of remote files missing on local.

--- a/main_test.go
+++ b/main_test.go
@@ -9,8 +9,8 @@ import (
 )
 
 func TestFilesList(t *testing.T) {
-	cacheFile := opts.cacheFile
-	opts.cacheFile = "test/.cacheEmpty.txt"
+	cacheFile := opts.CacheFile
+	opts.CacheFile = "test/.cacheEmpty.txt"
 	current, diff := filesLists()
 
 	if current["barbaz.txt"] != "dac2e8bd758efb58a30f9fcd7ac28b1b" ||
@@ -23,7 +23,7 @@ func TestFilesList(t *testing.T) {
 		t.Error("Expected diff to hold barbaz.txt and foobar.html")
 	}
 
-	opts.cacheFile = cacheFile
+	opts.CacheFile = cacheFile
 }
 
 func TestUpload(t *testing.T) {
@@ -146,13 +146,13 @@ func TestUploadRecoverable(t *testing.T) {
 }
 
 func TestIntegrationMain(t *testing.T) {
-	if _, err := os.Create(opts.cacheFile); err != nil {
+	if _, err := os.Create(opts.CacheFile); err != nil {
 		t.Fatal("Failed to truncate the cache file")
 	}
 
 	upFn, uploads := fakeUploaderGen()
 	_ = upFn
-	opts.region = "us-west-1"
+	opts.Region = "us-west-1"
 	opts.quiet = true
 	main()
 	opts.quiet = false

--- a/opts.go
+++ b/opts.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+type options struct {
+	WorkersCount int    `json:",omitempty"`
+	BucketName   string `json:",omitempty"`
+	Source       string `json:",omitempty"`
+	CacheFile    string `json:",omitempty"`
+	Region       string `json:",omitempty"`
+	Profile      string `json:",omitempty"`
+	Encrypt      bool   `json:",omitempty"`
+
+	dryRun, verbose, quiet,
+	doCache, doUpload, saveCfg bool
+	cfgFile string
+}
+
+func (o *options) dump(fname string) (err error) {
+	f, err := os.Create(fname)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		err2 := f.Close()
+		if err == nil {
+			err = err2
+		} else if err2 != nil {
+			err = fmt.Errorf("%v; %v", err, err2)
+		}
+	}()
+
+	var buf []byte
+	buf, err = json.MarshalIndent(o, "", "  ")
+	if err != nil {
+		return
+	}
+	buf = append(buf, "\n"[0])
+
+	_, err = f.Write(buf)
+
+	return
+}
+
+func (o *options) restore(fname string) (err error) {
+	f, err := os.Open(fname)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+
+		return err
+	}
+	defer func() {
+		_ = f.Close()
+	}()
+
+	tmp := options{}
+	dec := json.NewDecoder(f)
+	if err = dec.Decode(&tmp); err != nil {
+		return
+	}
+
+	o.merge(tmp)
+
+	return nil
+}
+
+func (o *options) merge(other options) {
+	if x := other.WorkersCount; x != 0 {
+		o.WorkersCount = x
+	}
+	if x := other.BucketName; x != "" {
+		o.BucketName = x
+	}
+	if x := other.Source; x != "" {
+		o.Source = x
+	}
+	if x := other.CacheFile; x != "" {
+		o.CacheFile = x
+	}
+	if x := other.Region; x != "" {
+		o.Region = x
+	}
+	if x := other.Profile; x != "" {
+		o.Profile = x
+	}
+	if x := other.Encrypt; x {
+		o.Encrypt = x
+	}
+
+	// skipping the rest of the fields, they can never come from an unmarshalled file anyway.
+}

--- a/setup_test.go
+++ b/setup_test.go
@@ -17,12 +17,12 @@ const (
 var fakeBuffer *bytes.Buffer
 
 func TestValidateCmdLineFlags(t *testing.T) {
-	opts1 := &options{bucketName: "example_bucket", source: "test/output", cacheFile: "test/.go3up.txt", region: "us-west-1"}
+	opts1 := &options{BucketName: "example_bucket", Source: "test/output", CacheFile: "test/.go3up.txt", Region: "us-west-1"}
 	if err := validateCmdLineFlags(opts1); err != nil {
 		t.Errorf("Expected %v to pass validation", opts1)
 	}
 
-	opts1 = &options{bucketName: "", source: "test/output", cacheFile: "test/.go3up.txt"}
+	opts1 = &options{BucketName: "", Source: "test/output", CacheFile: "test/.go3up.txt"}
 	if err := validateCmdLineFlags(opts1); err == nil {
 		t.Error("Expected to fail validation")
 	}
@@ -71,9 +71,9 @@ func fakeUploaderGen(opts ...int) (fn uploader, out *([]*sourceFile)) {
 }
 
 func init() {
-	opts.bucketName = "example_bucket"
-	opts.source = "test/output"
-	opts.cacheFile = "test/.go3up.txt"
+	opts.BucketName = "example_bucket"
+	opts.Source = "test/output"
+	opts.CacheFile = "test/.go3up.txt"
 	appEnv = "test"
 	fakeBuffer := &bytes.Buffer{}
 	say = loggerGen(fakeBuffer)

--- a/source_file_test.go
+++ b/source_file_test.go
@@ -1,16 +1,14 @@
 package main
 
 import (
-	"bytes"
-	"encoding/hex"
 	"sync"
 	"testing"
 )
 
 func TestHeadersMerge(t *testing.T) {
-	h1, h2 := headers{"foo": {"foo1"}, "bar": {"bar1", "bar2"}},
-		headersDef{"baz": "baz1"}
-	expected := headers{"foo": {"foo1"}, "bar": {"bar1", "bar2"}, "baz": {"baz1"}}
+	h1, h2 := headers{"foo": "foo1", "bar": "bar1"},
+		headers{"baz": "baz1"}
+	expected := headers{"foo": "foo1", "bar": "bar1", "baz": "baz1"}
 
 	if h1.merge(h2); !h1.equal(expected) {
 		t.Errorf("Expected %v to equal %v", h1, expected)
@@ -18,10 +16,9 @@ func TestHeadersMerge(t *testing.T) {
 }
 
 func TestHeaderEqual(t *testing.T) {
-	h1, h2, h3, h4 := headers{"foo": {"foo1"}, "bar": {"bar1", "bar2"}},
-		headers{"foo": {"foo1"}, "bar": {"bar1", "bar2"}},
-		headers{"foo": {"foo1"}, "bar": {"bar1"}},
-		headers{"foo": {"foo1"}}
+	h1, h2, h3 := headers{"foo": "foo1", "bar": "bar1"},
+		headers{"foo": "foo1", "bar": "bar1"},
+		headers{"foo": "foo1"}
 
 	if !h1.equal(h2) {
 		t.Errorf("Expected %v to equal %v", h1, h2)
@@ -30,22 +27,18 @@ func TestHeaderEqual(t *testing.T) {
 	if h1.equal(h3) {
 		t.Errorf("Expected %v NOT to equal %v", h1, h3)
 	}
-
-	if h1.equal(h4) {
-		t.Errorf("Expected %v NOT to equal %v", h1, h4)
-	}
 }
 
 func TestNewSourceFile(t *testing.T) {
 	fname := "foobar.html"
 	sf := newSourceFile(fname)
-	expectedHdrs := headers{ContentType: {"text/html; charset=utf-8"}, ContentEncoding: {"gzip"}, CacheControl: {"max-age=3600"}}
+	expectedHdrs := headers{ContentType: "text/html; charset=utf-8", ContentEncoding: "gzip", CacheControl: "max-age=3600"}
 
 	if sf.fname != fname {
 		t.Errorf("Expected fname to be set to %s got %s", fname, sf.fname)
 	}
 
-	if fpath := opts.source + "/" + fname; sf.fpath != fpath {
+	if fpath := opts.Source + "/" + fname; sf.fpath != fpath {
 		t.Errorf("Expected fpath to be set to %s got %s", fpath, sf.fpath)
 	}
 
@@ -65,37 +58,10 @@ func TestNewSourceFile(t *testing.T) {
 
 	for fname, ttl := range tests {
 		sf = newSourceFile(fname)
-		expectedHdrs = headers{ContentType: {"text/html; charset=utf-8"}, ContentEncoding: {"gzip"}, CacheControl: {"max-age=" + ttl}}
+		expectedHdrs = headers{ContentType: "text/html; charset=utf-8", ContentEncoding: "gzip", CacheControl: "max-age=" + ttl}
 		if !sf.hdrs.equal(expectedHdrs) {
 			t.Errorf("Expected hdrs to be set to %v got %v", expectedHdrs, sf.hdrs)
 		}
-	}
-}
-
-func TestSourceFileBody(t *testing.T) {
-	fname := "foobar.html"
-	sf := newSourceFile(fname)
-	expectedContent := "1f8b080000096e8800ff72cbcf57704a2ce202040000ffff4f79994a08000000"
-	expected, _ := hex.DecodeString(expectedContent)
-
-	if actual, _ := sf.body(); !bytes.Equal(expected, actual) {
-		t.Error("Expected to get compressed content")
-	}
-
-	fname = "barbaz.txt"
-	sf = newSourceFile(fname)
-	expectedStr := "Bar Baz\n"
-
-	if actual, _ := sf.body(); string(actual) != expectedStr {
-		t.Errorf("Expected to get %s got %s", expectedStr, actual)
-	}
-
-	fname = "bogus"
-	sf = newSourceFile(fname)
-	expectedStr = ""
-
-	if actual, err := sf.body(); string(actual) != expectedStr || err == nil {
-		t.Errorf("Expected to get blank body and an error. Got no error and %s", actual)
 	}
 }
 

--- a/test/.go3up.txt
+++ b/test/.go3up.txt
@@ -1,0 +1,2 @@
+barbaz.txt:dac2e8bd758efb58a30f9fcd7ac28b1b
+foobar.html:01677e4c0ae5468b9b8b823487f14524

--- a/utils.go
+++ b/utils.go
@@ -23,7 +23,7 @@ func loggerGen(buffers ...*bytes.Buffer) func(msgs ...string) {
 		m := msg(msgs...)
 
 		if len(buffers) > 0 {
-			buffers[0].WriteString(m)
+			_, _ = buffers[0].WriteString(m)
 			return
 		}
 


### PR DESCRIPTION
- replaced goamz by the aws-sdk-go and with that occasion we got both multipart uploads working as well as files streaming (whereas previously we read them in "slurp" mode);
- thanks to V4 requests signing we get the hash of the content to be verified automatically;
- and thanks to the very flexible AWS auth mechanisms exposed by the SDK we now support all of (and in this order, with fallback to the next one if not available):
  - use AWS shared profile credentials (same ones that aws cli tool itself uses);
  - use EC2 role credentials;
  - use env credentials.
- the profile information will default to `AWS_DEFAULT_PROFILE` (same env variable used by aws cli) and can be overriden via -profile command line flag; Same goes for region (default taken from
  `AWS_DEFAULT_REGION`).

The app should otherwise pretty much work unchanged. Except for being more flexible with authentication options and being able to upload large files without needing gobs of RAM.
